### PR TITLE
BinanceAPI.NET - Version 6.0.7.8

### DIFF
--- a/API-Test/API-Test.cs
+++ b/API-Test/API-Test.cs
@@ -146,11 +146,11 @@ namespace API_Test
 
                     //ExchangeInfoTest.Run(client);
 
-                    //SocketTest.Run(socketClient);
+                    SocketTest.Run(socketClient);
 
                     //OrderTest.Run(client);
 
-                    Requests.Run(socketClient, client);
+                    //Requests.Run(socketClient, client);
                 }
             });
 

--- a/API-Test/Tests/SocketTest.cs
+++ b/API-Test/Tests/SocketTest.cs
@@ -75,10 +75,61 @@ namespace API_Test
                     await sub.ReconnectSocketAsync().ConfigureAwait(false);
 
                     // work work
-                    await Task.Delay(20000).ConfigureAwait(false);
+                    await Task.Delay(5000).ConfigureAwait(false);
 
-                    // Destroy everything and unsubscribe, this should cause UnsubscribeAllAsync to do nothing
-                    await sub.CloseAndDisposeSubscriptionAsync().ConfigureAwait(false);
+                    // Unsubscribe
+                    bool b = await sub.UnsubscribeAsync().ConfigureAwait(false);
+                    if (b)
+                    {
+                        Console.WriteLine("Unsubscribed Successfully");
+                    }
+
+                    // wait
+                    await Task.Delay(5000).ConfigureAwait(false);
+
+                    // Resubscribe
+                    bool b2 = await sub.ResubscribeAsync().ConfigureAwait(false);
+                    if (b2)
+                    {
+                        Console.WriteLine("Resubscribed Successfully");
+                    }
+
+                    // wait
+                    await Task.Delay(5000).ConfigureAwait(false);
+
+                    // Destroy everything and unsubscribe
+                    bool b3 = await sub.DisposeAsync().ConfigureAwait(false);
+                    if (b3)
+                    {
+                        Console.WriteLine("Disposed Successfully");
+                    }
+
+                    // wait
+                    await Task.Delay(5000).ConfigureAwait(false);
+
+                    sub = null;
+                    Console.WriteLine("Create New Socket");
+
+                    sub = socketClient.Spot.SubscribeToBookTickerUpdatesAsync("BTCUSDT", data =>
+                    {
+                        // Uncomment to see output from the Socket
+                        Console.WriteLine("[" + data.Data.UpdateId +
+                            "]| BestAsk: " + data.Data.BestAskPrice.Normalize().ToString("0.00") +
+                            " | Ask Quan: " + data.Data.BestAskQuantity.Normalize().ToString("000.00000#####") +
+                            " | BestBid :" + data.Data.BestBidPrice.Normalize().ToString("0.00") +
+                            " | BidQuantity :" + data.Data.BestBidQuantity.Normalize().ToString("000.00000#####"));
+                    }).Result.Data;
+
+                    await Task.Delay(5000).ConfigureAwait(false);
+
+                    // Destroy everything and unsubscribe
+                    bool b4 = await sub.DisposeAsync().ConfigureAwait(false);
+                    if (b4)
+                    {
+                        Console.WriteLine("Disposed Successfully");
+                    }
+
+                    Console.WriteLine("Completed");
 
                     //// TEST BEGINS
                     //for (int i = 0; i < 1000; i++)
@@ -88,15 +139,13 @@ namespace API_Test
                     //    // Last Subscription Socket Action Time In Ticks
                     //    Console.WriteLine(sub.Connection.Socket.LastActionTime.Ticks);
                     //}
-
-                    _ = socketClient.UnsubscribeAsync(sub).ConfigureAwait(false);
                 }).ConfigureAwait(false);
             });
         }
 
         private static void BinanceSocket_StatusChanged(ConnectionStatus obj)
         {
-            Console.WriteLine(obj.ToString());
+            Console.WriteLine("Status: " + obj.ToString());
         }
 
     }

--- a/Binance-API/Binance-API/Enums/ConnectionStatus.cs
+++ b/Binance-API/Binance-API/Enums/ConnectionStatus.cs
@@ -62,6 +62,11 @@ namespace BinanceAPI.Enums
         /// <summary>
         /// Waiting for reconnect attempt
         /// </summary>
-        Waiting = 6
+        Waiting = 6,
+
+        /// <summary>
+        /// Unsubscribed and Waiting
+        /// </summary>
+        Unsubscribed = 7
     }
 }

--- a/Binance-API/Binance-API/Logging/TheLog.cs
+++ b/Binance-API/Binance-API/Logging/TheLog.cs
@@ -37,22 +37,22 @@ namespace BinanceAPI
         /// <summary>
         /// Binance Time Log
         /// </summary>
-        public static Logging? TimeLog { get; set; }
+        public static Logging TimeLog { get; set; }
 
         /// <summary>
         /// Binance Client Log
         /// </summary>
-        public static Logging? ClientLog { get; set; }
+        public static Logging ClientLog { get; set; }
 
         /// <summary>
         /// Socket Client Log
         /// </summary>
-        public static Logging? SocketLog { get; set; }
+        public static Logging SocketLog { get; set; }
 
         /// <summary>
         /// Order Book Log
         /// </summary>
-        public static Logging? OrderBookLog { get; set; }
+        public static Logging OrderBookLog { get; set; }
 
         internal static void StartTimeLog(string timeLogPath, LogLevel timeLogLevel, bool LogToConsole)
         {

--- a/Binance-API/BinanceAPI.csproj
+++ b/Binance-API/BinanceAPI.csproj
@@ -12,10 +12,10 @@
 
 	<PropertyGroup>
 		<Authors>S Christison</Authors>
-		<PackageVersion>6.0.7.7</PackageVersion>
-		<AssemblyVersion>6.0.7.7</AssemblyVersion>
-		<FileVersion>6.0.7.7</FileVersion>
-		<Version>6.0.7.7</Version>
+		<PackageVersion>6.0.7.8</PackageVersion>
+		<AssemblyVersion>6.0.7.8</AssemblyVersion>
+		<FileVersion>6.0.7.8</FileVersion>
+		<Version>6.0.7.8</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Binance-API/BinanceAPI.xml
+++ b/Binance-API/BinanceAPI.xml
@@ -270,21 +270,24 @@
         </member>
         <member name="M:BinanceAPI.ClientBase.BaseSocketClient.UnsubscribeAsync">
             <summary>
-            Unsubscribe and Dispose the Socket
+            Unsubscribe the Socket
+            <para>You can only call this method when <see cref="F:BinanceAPI.Enums.ConnectionStatus.Connected"/></para>
             </summary>
             <returns></returns>
         </member>
-        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.CloseAndDisposeSubscriptionAsync">
+        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.ResubscribeAsync">
             <summary>
-            Closes the subscription on this connection
-            <para>Closes the connection if the correct subscription is provided</para>
+            Resubscribe the Socket
+            <para>You can only call this when <see cref="F:BinanceAPI.Enums.ConnectionStatus.Unsubscribed"/></para>
             </summary>
             <returns></returns>
         </member>
-        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.DisposeAsync">
+        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.ReconnectSocketAsync">
             <summary>
-            Close and Dispose the Socket and all Message Handlers
+            Internal Reconnection method, Will reset the socket so it can be automatically reconnected or closed permanantly
+            <para>You can call this if you think the socket is disconnected</para>
             </summary>
+            <returns></returns>
         </member>
         <member name="M:BinanceAPI.ClientBase.BaseSocketClient.SendAndWaitAsync(BinanceAPI.Objects.Other.BinanceSocketRequest,System.TimeSpan,System.Func{Newtonsoft.Json.Linq.JToken,System.Boolean})">
             <summary>
@@ -295,41 +298,12 @@
             <param name="handler">The response handler</param>
             <returns></returns>
         </member>
-        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.SendLoopAsync">
+        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.DisposeAsync">
             <summary>
-            Loop for sending data
+            Close and Dispose the Socket and all Message Handlers
+            <para>This will <see cref="F:BinanceAPI.Enums.ConnectionStatus.Closed"/> the WebSocket</para>
+            <para>You will have to create a new socket from constructor if you call this</para>
             </summary>
-            <returns></returns>
-        </member>
-        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.ConnectionAttemptInternalAsync">
-            <summary>
-            Attempt to Connect and Start the WebSocket
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.NewWebSocketInternal(System.Boolean)">
-            <summary>
-            Create the WebSocket
-            </summary>
-        </member>
-        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.InternalConnectSocketAsync">
-            <summary>
-            Connect the Socket
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.ReconnectSocketAsync(System.Boolean)">
-            <summary>
-            Internal reset method, Will prepare the socket to be reset so it can be automatically reconnected or closed permanantly
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:BinanceAPI.ClientBase.BaseSocketClient.WaitForTasksSimple(System.Boolean)">
-            <summary>
-            Wait for Send/Digest loop to start/stop
-            </summary>
-            <param name="start"></param>
-            <returns></returns>
         </member>
         <member name="T:BinanceAPI.Converters.AccountTypeConverter">
             <summary>
@@ -576,6 +550,11 @@
         <member name="F:BinanceAPI.Enums.ConnectionStatus.Waiting">
             <summary>
             Waiting for reconnect attempt
+            </summary>
+        </member>
+        <member name="F:BinanceAPI.Enums.ConnectionStatus.Unsubscribed">
+            <summary>
+            Unsubscribed and Waiting
             </summary>
         </member>
         <member name="T:BinanceAPI.Enums.DepositStatus">
@@ -7622,13 +7601,6 @@
             </summary>
             <param name="socketClient">The connection on which to unsubscribe</param>
             <param name="Request">The Socket Request</param>
-            <returns></returns>
-        </member>
-        <member name="M:BinanceAPI.ClientHosts.SocketClientHost.UnsubscribeAsync(BinanceAPI.ClientBase.BaseSocketClient)">
-            <summary>
-            Unsubscribe an update subscription
-            </summary>
-            <param name="client">The Base Socket Client to Ubsubscribe</param>
             <returns></returns>
         </member>
         <member name="M:BinanceAPI.ClientHosts.SocketClientHost.Dispose">

--- a/Binance-API/ClientHosts/SocketClientHost.cs
+++ b/Binance-API/ClientHosts/SocketClientHost.cs
@@ -294,19 +294,6 @@ namespace BinanceAPI.ClientHosts
         }
 
         /// <summary>
-        /// Unsubscribe an update subscription
-        /// </summary>
-        /// <param name="client">The Base Socket Client to Ubsubscribe</param>
-        /// <returns></returns>
-        public async Task UnsubscribeAsync(BaseSocketClient client)
-        {
-#if DEBUG
-            SocketLog?.Info("Closing subscription " + client.Request.Id);
-#endif
-            await client.CloseAndDisposeSubscriptionAsync().ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Dispose the client
         /// </summary>
         public override void Dispose()

--- a/Binance-API/Logging/Logging/Queue.cs
+++ b/Binance-API/Logging/Logging/Queue.cs
@@ -34,7 +34,7 @@ namespace BinanceAPI
             {
                 try
                 {
-                    if (loggedMessages.Count > 0)
+                    while (loggedMessages.TryPeek(out _))
                     {
                         bool message = loggedMessages.TryDequeue(out Message result);
 
@@ -51,7 +51,10 @@ namespace BinanceAPI
                         }
                     }
                 }
-                catch { }
+                catch
+                {
+                    // Ignore
+                }
                 finally
                 {
                     slim.Release();

--- a/Binance-API/README.md
+++ b/Binance-API/README.md
@@ -1,3 +1,10 @@
+### Version 6.0.7.8
+- [x] You can now `Unsubscribe` Sockets Separately
+- [x] You can now `Resubscribe` Sockets Separately
+- [x] You can now `Dispose` Sockets which will automatically unsubscribe
+- [x] You can now `Recreate BaseSocketClients` with a small delay
+- [x] Sockets will no longer throw some exceptions
+
 ### Version 6.0.7.7
 - [x] Numerous bug fixes and optimizations
 


### PR DESCRIPTION
- [x] You can now `Unsubscribe` Sockets Separately
- [x] You can now `Resubscribe` Sockets Separately
- [x] You can now `Dispose` Sockets which will automatically unsubscribe
- [x] You can now `Recreate BaseSocketClients` with a small delay
- [x] Sockets will no longer throw some exceptions